### PR TITLE
Use same network as other components

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     volumes:
       - "psql-data:/var/lib/postgresql/data"
       - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
-    networks:
-      - cvt-pdf-analyzer-network
     environment:
       - POSTGRES_PASSWORD
       - POSTGRES_USER
@@ -27,8 +25,6 @@ services:
       - "8080:8080"
     depends_on:
       - psql      
-    networks:
-      - cvt-pdf-analyzer-network
     environment:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://psql:5432/${POSTGRES_DB}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
@@ -39,5 +35,6 @@ volumes:
   psql-data:
 
 networks:
-  cvt-pdf-analyzer-network:
-
+    default:
+        external:
+            name: cvt-oss


### PR DESCRIPTION
Compare with https://github.com/cvt-oss/campaign-reports/blob/master/docker-compose.yml - we need to see each other, so this seem to me as an easiest way for now.